### PR TITLE
reorder the linker sections; make reset_handler the entry point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- The linker sections have renamed / reorder to make `arm-none-eabi-size -A`
+  more useful. You'll now see something like this:
+
+```
+$ arm-none-eabi-size -A hello
+hello  :
+section                size        addr
+.vector_table          1024   134217728
+.text                   288   134218752
+.rodata                  14   134219040
+```
+
+- `cortex-m-rt::reset_handler` is now the entry point of all programs that link
+  to `cortex-m-rt`. This makes GDB's `load` command work correctly. It will now
+  set the Program Counter to `reset_handler` after flashing the program so
+  there's no need to reset the microcontroller after flashing.
+
 ## [v0.2.1] - 2017-05-07
 
 ### Fixed

--- a/link.x
+++ b/link.x
@@ -2,21 +2,32 @@ INCLUDE memory.x
 
 SECTIONS
 {
-  .text ORIGIN(FLASH) :
+  .vector_table ORIGIN(FLASH) :
   {
     /* Vector table */
-    _VECTOR_TABLE = .;
+    _svector_table = .;
     LONG(_stack_start);
 
-    KEEP(*(.rodata.reset_handler));
+    KEEP(*(.vector_table.reset_handler));
 
-    KEEP(*(.rodata.exceptions));
+    KEEP(*(.vector_table.exceptions));
     _eexceptions = .;
 
-    KEEP(*(.rodata.interrupts));
+    KEEP(*(.vector_table.interrupts));
     _einterrupts = .;
+  } > FLASH
+
+  .text : ALIGN(4)
+  {
+    /* Put reset handler first in .text section so it ends up as the entry */
+    /* point of the program. */
+    KEEP(*(.text.reset_handler));
 
     *(.text .text.*);
+  } > FLASH
+
+  .rodata : ALIGN(4)
+  {
     *(.rodata .rodata.*);
   } > FLASH
 

--- a/link.x
+++ b/link.x
@@ -21,7 +21,7 @@ SECTIONS
   {
     /* Put reset handler first in .text section so it ends up as the entry */
     /* point of the program. */
-    KEEP(*(.text.reset_handler));
+    KEEP(*(.reset_handler));
 
     *(.text .text.*);
   } > FLASH

--- a/link.x
+++ b/link.x
@@ -10,10 +10,10 @@ SECTIONS
 
     KEEP(*(.vector_table.reset_handler));
 
-    KEEP(*(.vector_table.exceptions));
+    KEEP(*(.rodata.exceptions));
     _eexceptions = .;
 
-    KEEP(*(.vector_table.interrupts));
+    KEEP(*(.rodata.interrupts));
     _einterrupts = .;
   } > FLASH
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,7 +213,7 @@ static RESET_HANDLER: unsafe extern "C" fn() -> ! = reset_handler;
 
 #[allow(dead_code)]
 #[cfg(feature = "exceptions")]
-#[link_section = ".vector_table.exceptions"]
+#[link_section = ".rodata.exceptions"]
 #[used]
 static EXCEPTIONS: exception::Handlers = exception::Handlers {
     ..exception::DEFAULT_HANDLERS

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,7 +189,7 @@ extern "C" {
 /// The reset handler
 ///
 /// This is the entry point of all programs
-#[link_section = ".text.reset_handler"]
+#[link_section = ".reset_handler"]
 unsafe extern "C" fn reset_handler() -> ! {
     ::r0::zero_bss(&mut _sbss, &mut _ebss);
     ::r0::init_data(&mut _sdata, &mut _edata, &_sidata);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,6 +189,7 @@ extern "C" {
 /// The reset handler
 ///
 /// This is the entry point of all programs
+#[link_section = ".text.reset_handler"]
 unsafe extern "C" fn reset_handler() -> ! {
     ::r0::zero_bss(&mut _sbss, &mut _ebss);
     ::r0::init_data(&mut _sdata, &mut _edata, &_sidata);
@@ -207,12 +208,12 @@ unsafe extern "C" fn reset_handler() -> ! {
 
 #[allow(dead_code)]
 #[used]
-#[link_section = ".rodata.reset_handler"]
+#[link_section = ".vector_table.reset_handler"]
 static RESET_HANDLER: unsafe extern "C" fn() -> ! = reset_handler;
 
 #[allow(dead_code)]
 #[cfg(feature = "exceptions")]
-#[link_section = ".rodata.exceptions"]
+#[link_section = ".vector_table.exceptions"]
 #[used]
 static EXCEPTIONS: exception::Handlers = exception::Handlers {
     ..exception::DEFAULT_HANDLERS


### PR DESCRIPTION
Before this commit the .rodata sections of the inputs were placed in the output
.text section. As the vector table is in the .rodata of the cortex-m-rt crate
this placed the vector table first in the output .text section:

``` console
$ arm-none-eabi-objdump -Cd hello
Disassembly of section .text:

08000000 <_VECTOR_TABLE>:
 8000000:       10002000        .word   0x10002000

08000004 <cortex_m_rt::RESET_HANDLER>:
 8000004:       08000405                                ....
(..)

$ arm-none-eabi-readelf -h hello | grep Entry
  Entry point address:               0x8000000
```

With this memory layout using `load` and then `step` on a GDB session made the
processor execute the vector table (PC = 0x08000000).

This commit places the .rodata sections of the inputs into the output .rodata
section, and also moves the reset_handler code to the start the output .text
section. This turns the reset_handler into the entry point of the program.

``` console
$ arm-none-eabi-objdump -Cd hello
Disassembly of section .text:

08000410 <cortex_m_rt::reset_handler>:
(..)

$ arm-none-eabi-readelf -h hello | grep Entry
  Entry point address:               0x8000410
```

With these changes the GDB commands `load` and `step` work correctly: `load`
sets the PC = reset_handler.

Also the `size` output is now more helpful:

``` console
$ arm-none-eabi-size -Ax hello
section                 size         addr
.vector_table          0x400    0x8000000
.text                  0x120    0x8000400
.rodata                  0xd    0x8000520
.bss                     0x4   0x20000000
.data                    0x4   0x20000004
```

---

r? @whitequark

With this we should be able to drop the `monitor reset halt` command from the
`.gdbinit` file in cortex-m-quickstart.