### PR TITLE
Explicitly place non-suffixed sections

### DIFF
--- a/link.x
+++ b/link.x
@@ -15,21 +15,21 @@ SECTIONS
     KEEP(*(.rodata.interrupts));
     __interrupts = .;
 
-    *(.text.*);
-    *(.rodata.*);
+    *(.text .text.*);
+    *(.rodata .rodata.*);
   } > FLASH
 
   .bss : ALIGN(4)
   {
     _sbss = .;
-    *(.bss.*);
+    *(.bss .bss.*);
     _ebss = ALIGN(4);
   } > RAM
 
   .data : ALIGN(4)
   {
     _sdata = .;
-    *(.data.*);
+    *(.data .data.*);
     _edata = ALIGN(4);
   } > RAM AT > FLASH
 


### PR DESCRIPTION
The `*(.data.*);` command does not place the `.data` section, which may lead
to incorrect placement of symbols, etc. I have not verified that the current
linker script leads to broken products, but if not it is by accident.