### PR TITLE
Rename __exceptions/__interrupts symbols to reduce confusion

### DIFF
--- a/link.x
+++ b/link.x
@@ -9,11 +9,12 @@ SECTIONS
     LONG(_stack_start);
 
     KEEP(*(.rodata.reset_handler));
+
     KEEP(*(.rodata.exceptions));
-    __exceptions = .;
+    _eexceptions = .;
 
     KEEP(*(.rodata.interrupts));
-    __interrupts = .;
+    _einterrupts = .;
 
     *(.text.*);
     *(.rodata.*);
@@ -55,24 +56,24 @@ SECTIONS
 }
 
 /* Do not exceed this mark in the error messages below                | */
-ASSERT(__exceptions - ORIGIN(FLASH) > 8, "
+ASSERT(_eexceptions - ORIGIN(FLASH) > 8, "
 You must specify the exception handlers.
 Create a non `pub` static variable with type
 `cortex_m::exception::Handlers` and place it in the
 '.rodata.exceptions' section. (cf. #[link_section]). Apply the
 `#[used]` attribute to the variable to make it reach the linker.");
 
-ASSERT(__exceptions - ORIGIN(FLASH) == 0x40, "
+ASSERT(_eexceptions - ORIGIN(FLASH) == 0x40, "
 Invalid '.rodata.exceptions' section.
 Make sure to place a static with type `cortex_m::exception::Handlers`
 in that section (cf. #[link_section]) ONLY ONCE.");
 
-ASSERT(__interrupts - __exceptions > 0, "
+ASSERT(_einterrupts - _eexceptions > 0, "
 You must specify the interrupt handlers.
 Create a non `pub` static variable and place it in the
 '.rodata.interrupts' section. (cf. #[link_section]). Apply the
 `#[used]` attribute to the variable to help it reach the linker.");
 
-ASSERT(__interrupts - __exceptions <= 0x3c0, "
+ASSERT(_einterrupts - _eexceptions <= 0x3c0, "
 There can't be more than 240 interrupt handlers.
 Fix the '.rodata.interrupts' section. (cf. #[link_section])");


### PR DESCRIPTION
Right now these symbols get placed *after* their respective contents,
but not named to indicate that.