### PR TITLE
add a _sheap symbol where a heap can be located

### DIFF
--- a/link.x
+++ b/link.x
@@ -47,6 +47,9 @@ SECTIONS
 
   _sidata = LOADADDR(.data);
 
+  /* The heap starts right after the .bss + .data section ends */
+  _sheap = _edata;
+
   /* Due to an unfortunate combination of legacy concerns,
      toolchain drawbacks, and insufficient attention to detail,
      rustc has no choice but to mark .debug_gdb_scripts as allocatable.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,8 @@
 //!   on a per exception basis by opting out of the "exceptions" Cargo feature
 //!   and then defining the following `struct`
 //!
+//! - A `_sheap` symbol at whose address you can locate the heap.
+//!
 //! ``` ignore,no_run
 //! use cortex_m::exception;
 //!


### PR DESCRIPTION
closes #5

I'll merge this after I write some docs for cortex-m-quickstart