### PR TITLE
[WIP] Optional .reserved region between .vector_table and .text

### DIFF
--- a/link.x
+++ b/link.x
@@ -18,14 +18,8 @@ SECTIONS
   } > FLASH
 
   PROVIDE(_stext = _einterrupts);
-  _reserved_size = _stext - _einterrupts;
-
-  .reserved : ALIGN(4)
-  {
-    . += _reserved_size;
-  } > FLASH
   
-  .text : ALIGN(4)
+  .text _stext : ALIGN(4)
   {
     /* Put reset handler first in .text section so it ends up as the entry */
     /* point of the program. */

--- a/link.x
+++ b/link.x
@@ -1,3 +1,5 @@
+text_offset = 0;
+
 INCLUDE memory.x
 
 SECTIONS
@@ -15,6 +17,11 @@ SECTIONS
 
     KEEP(*(.rodata.interrupts));
     _einterrupts = .;
+  } > FLASH
+
+  .reserved : ALIGN(4)
+  {
+    . += text_offset;
   } > FLASH
 
   .text : ALIGN(4)

--- a/link.x
+++ b/link.x
@@ -17,8 +17,8 @@ SECTIONS
     _einterrupts = .;
   } > FLASH
 
-  PROVIDE(_text_start = _einterrupts);
-  _reserved_size = _text_start - _einterrupts;
+  PROVIDE(_stext = _einterrupts);
+  _reserved_size = _stext - _einterrupts;
 
   .reserved : ALIGN(4)
   {
@@ -100,10 +100,10 @@ ASSERT(_einterrupts - _eexceptions <= 0x3c0, "
 There can't be more than 240 interrupt handlers.
 Fix the '.rodata.interrupts' section. (cf. #[link_section])");
 
-ASSERT(_einterrupts <= _text_start, "
+ASSERT(_einterrupts <= _stext, "
 The '.text' section can't be placed inside '.vector_table' section.
-Set '_text_start' to an adress greater than '_einterrupts'");
+Set '_stext' to an adress greater than '_einterrupts'");
 
-ASSERT(_text_start < ORIGIN(FLASH) + LENGTH(FLASH), "
+ASSERT(_stext < ORIGIN(FLASH) + LENGTH(FLASH), "
 The '.text' section must be placed inside the FLASH memory
-Set '_text_start' to an adress smaller than 'ORIGIN(FLASH) + LENGTH(FLASH)");
+Set '_stext' to an adress smaller than 'ORIGIN(FLASH) + LENGTH(FLASH)");

--- a/link.x
+++ b/link.x
@@ -106,4 +106,4 @@ Set '_stext' to an adress greater than '_einterrupts'");
 
 ASSERT(_stext < ORIGIN(FLASH) + LENGTH(FLASH), "
 The '.text' section must be placed inside the FLASH memory
-Set '_stext' to an adress smaller than 'ORIGIN(FLASH) + LENGTH(FLASH)");
+Set '_stext' to an address smaller than 'ORIGIN(FLASH) + LENGTH(FLASH)");

--- a/link.x
+++ b/link.x
@@ -99,3 +99,11 @@ Create a non `pub` static variable and place it in the
 ASSERT(_einterrupts - _eexceptions <= 0x3c0, "
 There can't be more than 240 interrupt handlers.
 Fix the '.rodata.interrupts' section. (cf. #[link_section])");
+
+ASSERT(_einterrupts <= _text_start, "
+The '.text' section can't be placed inside '.vector_table' section.
+Set '_text_start' to an adress greater than '_einterrupts'");
+
+ASSERT(_text_start < ORIGIN(FLASH) + LENGTH(FLASH), "
+The '.text' section must be placed inside the FLASH memory
+Set '_text_start' to an adress smaller than 'ORIGIN(FLASH) + LENGTH(FLASH)");

--- a/link.x
+++ b/link.x
@@ -1,5 +1,3 @@
-text_offset = 0;
-
 INCLUDE memory.x
 
 SECTIONS
@@ -19,11 +17,14 @@ SECTIONS
     _einterrupts = .;
   } > FLASH
 
+  PROVIDE(_text_start = _einterrupts);
+  _reserved_size = _text_start - _einterrupts;
+
   .reserved : ALIGN(4)
   {
-    . += text_offset;
+    . += _reserved_size;
   } > FLASH
-
+  
   .text : ALIGN(4)
   {
     /* Put reset handler first in .text section so it ends up as the entry */


### PR DESCRIPTION
A simple way to fix #13 

Set text_offset in memory.x to override default value of 0

Since text_offset doesn't need to be set this is backwards compatible.

Is a simple fix like this wanted or is there a better solution that is preffered.

Is the form text_offset or text_start (or somthing similar) the preffered way to set this offset size?