### PR TITLE
[RFC] default panic! to abort, drop panic-* features, add panic_fmt! macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ keywords = ["arm", "cortex-m", "runtime", "startup"]
 license = "MIT OR Apache-2.0"
 name = "cortex-m-rt"
 repository = "https://github.com/japaric/cortex-m-rt"
-version = "0.2.4"
+version = "0.3.0"
 
 [dependencies]
 r0 = "0.2.1"
@@ -22,3 +22,5 @@ default = ["exceptions", "linker-script"]
 exceptions = ["cortex-m"]
 # generic linker script
 linker-script = []
+# provides a panic_fmt implementation that calls the abort instruction (`udf 0xfe`)
+abort-on-panic = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,17 +16,9 @@ r0 = "0.2.1"
 optional = true
 version = "0.2.7"
 
-[dependencies.cortex-m-semihosting]
-optional = true
-version = "0.1.3"
-
 [features]
 default = ["exceptions", "linker-script"]
 # service all exceptions using the default handler
 exceptions = ["cortex-m"]
 # generic linker script
 linker-script = []
-# prints panic messages to the ITM
-panic-over-itm = ["cortex-m"]
-# prints panic messages to the host stdout
-panic-over-semihosting = ["cortex-m-semihosting"]

--- a/src/lang_items.rs
+++ b/src/lang_items.rs
@@ -6,32 +6,21 @@ unsafe extern "C" fn panic_fmt(
     _file: &'static str,
     _line: u32,
 ) -> ! {
-    match () {
-        #[cfg(feature = "panic-over-itm")]
-        () => {
-            use cortex_m::itm;
-            use cortex_m::peripheral::ITM;
+    ::core::intrinsics::abort()
+}
 
-            let port = &(*ITM.get()).stim[0];
-            iprint!(port, "panicked at '");
-            itm::write_fmt(port, _args);
-            iprintln!(port, "', {}:{}", _file, _line);
+#[macro_export]
+macro_rules! panic_fmt {
+    ($f:expr) => {
+        #[export_name = "rust_begin_unwind"]
+        pub unsafe extern "C" fn _panic_fmt(
+            args: ::core::fmt::Arguments,
+            file: &'static str,
+            line: u32,
+        ) -> ! {
+            $f(args, file, line)
         }
-        #[cfg(feature = "panic-over-semihosting")]
-        () => {
-            hprint!("panicked at '");
-            ::cortex_m_semihosting::io::write_fmt(_args);
-            hprintln!("', {}:{}", _file, _line);
-        }
-        #[cfg(not(any(feature = "panic-over-itm",
-                      feature = "panic-over-semihosting")))]
-        () => {}
     }
-
-    #[cfg(target_arch = "arm")]
-    asm!("bkpt" :::: "volatile");
-
-    loop {}
 }
 
 /// Lang item required to make the normal `main` work in applications

--- a/src/lang_items.rs
+++ b/src/lang_items.rs
@@ -1,26 +1,12 @@
 /// Default panic handler
+#[cfg(feature = "abort-on-panic")]
 #[lang = "panic_fmt"]
-#[linkage = "weak"]
 unsafe extern "C" fn panic_fmt(
-    _args: ::core::fmt::Arguments,
-    _file: &'static str,
-    _line: u32,
+    _: ::core::fmt::Arguments,
+    _: &'static str,
+    _: u32,
 ) -> ! {
     ::core::intrinsics::abort()
-}
-
-#[macro_export]
-macro_rules! panic_fmt {
-    ($f:expr) => {
-        #[export_name = "rust_begin_unwind"]
-        pub unsafe extern "C" fn _panic_fmt(
-            args: ::core::fmt::Arguments,
-            file: &'static str,
-            line: u32,
-        ) -> ! {
-            $f(args, file, line)
-        }
-    }
 }
 
 /// Lang item required to make the normal `main` work in applications

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,18 +149,15 @@
 #![deny(warnings)]
 #![feature(asm)]
 #![feature(compiler_builtins_lib)]
+#![feature(core_intrinsics)]
 #![feature(lang_items)]
 #![feature(linkage)]
 #![feature(used)]
 #![no_std]
 
-#[cfg(any(feature = "panic-over-itm", feature = "exceptions"))]
-#[cfg_attr(feature = "panic-over-itm", macro_use)]
+#[cfg(feature = "exceptions")]
 extern crate cortex_m;
 extern crate compiler_builtins;
-#[cfg(feature = "panic-over-semihosting")]
-#[macro_use]
-extern crate cortex_m_semihosting;
 extern crate r0;
 
 mod lang_items;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,11 +145,11 @@
 //!  8000404:       b084            sub     sp, #16
 //! ```
 
+#![cfg_attr(feature = "abort-on-panic", feature(core_intrinsics))]
 #![deny(missing_docs)]
 #![deny(warnings)]
 #![feature(asm)]
 #![feature(compiler_builtins_lib)]
-#![feature(core_intrinsics)]
 #![feature(lang_items)]
 #![feature(linkage)]
 #![feature(used)]
@@ -186,8 +186,8 @@ extern "C" {
 /// This is the entry point of all programs
 #[link_section = ".reset_handler"]
 unsafe extern "C" fn reset_handler() -> ! {
-    ::r0::zero_bss(&mut _sbss, &mut _ebss);
-    ::r0::init_data(&mut _sdata, &mut _edata, &_sidata);
+    r0::zero_bss(&mut _sbss, &mut _ebss);
+    r0::init_data(&mut _sdata, &mut _edata, &_sidata);
 
     // Neither `argc` or `argv` make sense in bare metal context so we just
     // stub them


### PR DESCRIPTION
# What

I propose we drop the panic-* features in this repo.

# Why

If we want to use this crate *not* as a direct dependency of the top crate then,
IMO, it's better to have less features otherwise whatever other crate brings
this crate into the dependency graph will have to re-export a bunch of Cargo
features. The re-exports aggravate if there are more crates between the top
crate and the rt crate.

# How

We'll drop the panic-* features and change the panic_fmt lang item to be just a
call to `intrinsics::abort`. We'll also add a `panic_fmt!` macro to make it
easier and type safer to override the `panic_fmt` implementation.

# Downside: regression in debugging experience

Today is easy to turn panic!s into formatted strings: you can just enable the
"panic-over-semihosting" feature -- easy, assuming that cortex-m-rt is a direct
dependency of the top crate. With this proposed change you'll have to define the
formatting implementation yourself.

Do note that you can, at least, recover the filename and line information using
a debugger with the proposed default `panic!` equals abort implementation. The
abort will cause a hard fault exception and the default exception handler gives
you access to the stacked register and the r0 register points to a tuple that
contains the filename and line information. With code:

``` rust
fn main() {
    panic!("foo");
}
```

``` console
> # GDB

> continue
cortex_m_rt::default_handler (_sr=0x20004fd0) at (..)/cortex-m-rt/src/lib.rs:263

> p/x _sr.r0
$1 = 0x8000204

> x/5wx 0x8000204
0x8000204:      0x080001f4      0x00000003     0x080001f7      0x0000000b
0x8000214:      0x0000000d

> x/3c 0x080001f4
0x80001f4 <str.0>:      102 'f' 111 'o' 111 'o'

> x/11c 0x080001f7
0x80001f7 <str.1>:      115 's' 114 'r' 99 'c'  47 '/'  109 'm' 97 'a'  105 'i' 110 'n'
0x80001ff <str.1+8>:    46 '.'  114 'r' 115 's'

> # line number is at 0x8000214
```

# Alternatives

We could add an opt-out `panic_fmt` Cargo feature to this crate. When that
feature is enabled this crate will provide a `panic_fmt` implementation, and
when not the user will be responsible for defining the `panic_fmt` lang item
through some other way.

# Unresolved questions

- Take a closure or a path to function in the `panic_fmt!` macro?

Thoughts? @whitequark @pftbest