### PR TITLE
Use the new panic_fmt abi

### DIFF
--- a/src/lang_items.rs
+++ b/src/lang_items.rs
@@ -5,6 +5,7 @@ unsafe extern "C" fn panic_fmt(
     _: ::core::fmt::Arguments,
     _: &'static str,
     _: u32,
+    _: u32,
 ) -> ! {
     ::core::intrinsics::abort()
 }


### PR DESCRIPTION
Fixes a panic_fmt mismatch with newer rust compiler versions.

This ensures that newer rust compiler versions can optimize out the dead panic formatting machinery and prevents a big bloat of binary sizes.
 
cc https://github.com/rust-lang/rust/issues/43054