### PR TITLE
tweak the linker script to keep the EXCEPTIONS symbol (vector table)

### DIFF
--- a/link.x
+++ b/link.x
@@ -1,5 +1,12 @@
 INCLUDE memory.x
 
+/* With multiple codegen units the rlib produced for this crate has several object files in it. */
+/* Because the linker is Smart it may not look into all the object files and not pick up the */
+/* .vector_table.exceptions section. But we want it to! To workaround the problem we create an */
+/* undefined reference to the EXCEPTIONS symbol (located in .vector_table.exceptions); this way the */
+/* linker will look at all the object of the rlib and pick up our EXCEPTIONS symbol */
+EXTERN(EXCEPTIONS);
+
 /* Create an undefined reference to the INTERRUPTS symbol. This is required to
    force the linker to *not* drop the INTERRUPTS symbol if it comes from an
    object file that's passed to the linker *before* this crate */

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -410,10 +410,13 @@ extern "C" {
     fn SYS_TICK();
 }
 
+#[allow(private_no_mangle_statics)]
 #[cfg(target_arch = "arm")]
-#[used]
+#[doc(hidden)]
 #[link_section = ".vector_table.exceptions"]
-static EXCEPTIONS: [Option<unsafe extern "C" fn()>; 14] = [
+#[no_mangle]
+#[used]
+pub static EXCEPTIONS: [Option<unsafe extern "C" fn()>; 14] = [
     Some(NMI),
     Some(HARD_FAULT),
     Some(MEM_MANAGE),


### PR DESCRIPTION
fixes japaric/cortex-m-quickstart#19
fixes japaric/cortex-m-rt#35
closes japaric/cortex-m-quickstart#18