### PR TITLE
Put global asm behind target cfg

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -372,6 +372,7 @@ unsafe extern "C" fn reset_handler() -> ! {
     }
 }
 
+#[cfg(target_arch = "arm")]
 global_asm!(r#"
 .weak NMI
 NMI = DEFAULT_HANDLER


### PR DESCRIPTION
This will fix 
```
error: <inline asm>:2:1: error: unknown directive
.weak NMI
```
when doing `cargo build` and I hope it will help my IDE a little.
