### PR TITLE
drop the /DISCARD/ section

### DIFF
--- a/link.x
+++ b/link.x
@@ -92,13 +92,6 @@ SECTIONS
   .debug_gdb_scripts _stext (INFO) : {
     KEEP(*(.debug_gdb_scripts))
   }
-
-  /DISCARD/ :
-  {
-    /* Unused unwinding stuff */
-    *(.ARM.exidx.*)
-    *(.ARM.extab.*)
-  }
 }
 
 /* Do not exceed this mark in the error messages below                | */


### PR DESCRIPTION
TL;DR thanks to rust-lang/rust#45031 we no longer need this

Now with -C panic=abort all functions are marked with the `nouwind` attribute in
LLVM-IR. With this change LLVM won't generate undefined references to
`__aeabi_unwind_cpp_pr0` et al. which we don't use / supply but are required by
the AEABI standard in the case that a function that throw exceptions
exists (semantically, we never have any of those function with panic=abort but
the LLVM-IR didn't reflect this before).

---

the downside of this change is that users will need a recent-ish (1 week old or
newer) nightly or will run into linker errors.

So I'll wait a bit before merging this, I think.