### PR TITLE
discard the ARM.exidx.* section

### DIFF
--- a/link.x
+++ b/link.x
@@ -92,6 +92,11 @@ SECTIONS
   .debug_gdb_scripts _stext (INFO) : {
     KEEP(*(.debug_gdb_scripts))
   }
+
+  /DISCARD/ :
+  {
+    *(.ARM.exidx.*)
+  }
 }
 
 /* Do not exceed this mark in the error messages below                | */


### PR DESCRIPTION
It's related to stack unwinding and takes up FLASH memory. I doubt anyone is using it and we have
been discarding this section in all the released versions of this crate so this is not a breaking
change.

In the future, if need for this arises, we can add it back behind a Cargo feature, or without one if
that makes sense.