### PR TITLE
[RFC] enforce `main: fn() -> !`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ keywords = ["arm", "cortex-m", "runtime", "startup"]
 license = "MIT OR Apache-2.0"
 name = "cortex-m-rt"
 repository = "https://github.com/japaric/cortex-m-rt"
-version = "0.3.8"
+version = "0.4.0"
 
 [dependencies]
 cortex-m = "0.3.0"

--- a/src/lang_items.rs
+++ b/src/lang_items.rs
@@ -38,7 +38,7 @@ pub trait Termination {
     fn report(self) -> i32;
 }
 
-impl Termination for () {
+impl Termination for ! {
     fn report(self) -> i32 {
         0
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -287,6 +287,7 @@
 #![feature(lang_items)]
 #![feature(linkage)]
 #![feature(naked_functions)]
+#![feature(never_type)]
 #![feature(used)]
 #![no_std]
 
@@ -307,8 +308,10 @@ use cortex_m::exception::ExceptionFrame;
 
 extern "C" {
     // NOTE `rustc` forces this signature on us. See `src/lang_items.rs`
+    // NOTE the return type can only be the never type (`!`) because that's the only type that
+    // implements the `Termination` trait
     #[cfg(target_arch = "arm")]
-    fn main(argc: isize, argv: *const *const u8) -> isize;
+    fn main(argc: isize, argv: *const *const u8) -> !;
 
     // Boundaries of the .bss section
     static mut _ebss: u32;
@@ -341,7 +344,7 @@ unsafe extern "C" fn reset_handler() -> ! {
         () => {
             // Neither `argc` or `argv` make sense in bare metal context so we
             // just stub them
-            main(0, ::core::ptr::null());
+            main(0, ::core::ptr::null())
         }
         #[cfg(has_fpu)]
         () => {
@@ -355,20 +358,14 @@ unsafe extern "C" fn reset_handler() -> ! {
             // be executed *before* enabling the FPU and that would generate an
             // exception
             #[inline(never)]
-            fn main() {
+            fn main() -> ! {
                 unsafe {
-                    ::main(0, ::core::ptr::null());
+                    ::main(0, ::core::ptr::null())
                 }
             }
 
             main()
         }
-    }
-
-    // If `main` returns, then we go into "reactive" mode and simply attend
-    // interrupts as they occur.
-    loop {
-        asm!("wfi" :::: "volatile");
     }
 }
 


### PR DESCRIPTION
Now that the `Termination` trait has been implemented (cf. rust-lang/rust#46479) we can narrow down
the return type of `main` to be one of the types that implements the `Termination` trait.

This RFC proposes *only* implementing `Termination` for the never type (`!`) -- currently
`Termination` is only implemented for the unit type (`()`). With this change all programs that link
to `cortex-m-rt` are forced to set the signature of `main` to be `fn() -> !`.  The rationale here is
that a divergent (never ending) function better matches the logic of microcontroller programs.

When the change is implemented the user will be forced to make `main` into a divergent function.

This won't work:

``` rust
#![feature(termination_trait)]
#![no_std]

fn main() {}
//~^ error: the trait `cortex_m_rt::lang_items::Termination` is not implemented for `()`
```

Whereas this would works:

``` rust
#![feature(termination_trait)]
#![no_std]

fn main() -> ! {
    loop {}
}
```

### Drawbacks

Diagnostics for the `Termination` feature are rather bad at the moment. If this change is
implemented and you write a program where `main: fn()` but forget to add the
`#![feature(termination_trait)]` feature gate you get an unhelpful *linker* error:

``` rust
#![no_std]

fn main() {}
```

``` console
$ xargo build
(..)
  = note: /home/japaric/tmp/cortex-m-quickstart/target/thumbv7m-none-eabi/debug/deps/cortex_m_quickstart-0f691e4b3fe1bbf7.cortex_m_quickstart.rcgu.o: In function `main':
          cortex_m_quickstart-fd49a734b68c9115d8712982b4fdc764.rs:(.text.main+0x36): undefined reference to `cortex_m_rt::lang_items::start'
```

cc @pftbest
