### PR TITLE
don't over-constrain the .data section

### DIFF
--- a/link.x
+++ b/link.x
@@ -70,7 +70,7 @@ SECTIONS
     _ebss = .;
   } > RAM
 
-  .data _ebss : ALIGN(4)
+  .data : ALIGN(4)
   {
     _sidata = LOADADDR(.data);
     _sdata = .;


### PR DESCRIPTION
we were forcing the .data section to start at _ebss (end of the .bss section) but this was causing
linking errors in some cases:

``` console
error: linking with `arm-none-eabi-ld` failed: exit code: 1
(..)
note: arm-none-eabi-ld: section .data VMA [20000008,2000006f] overlaps section .bss VMA [20000000,2000000b]
```

removing this constraint fixes the problem. Even without it the linker will place the .data section
right after the .bss section