### PR TITLE
Use linker script to create weak aliases for exception handlers.

### DIFF
--- a/link.x
+++ b/link.x
@@ -12,6 +12,22 @@ EXTERN(EXCEPTIONS);
    object file that's passed to the linker *before* this crate */
 EXTERN(INTERRUPTS);
 
+/* Here we create a weak aliases for exception handlers. But since DEFAULT_HANDLER is
+   also a weak symbol, we have a weak aliases to a weak symbol. Such configuration is
+   not supported well through language features, so we have to do this in the linker
+   script. See cortex-m-rtfm/issues/39 and cortex-m-rt/issues/58 */
+EXTERN(DEFAULT_HANDLER);
+PROVIDE(NMI = DEFAULT_HANDLER);
+PROVIDE(HARD_FAULT = DEFAULT_HANDLER);
+PROVIDE(MEM_MANAGE = DEFAULT_HANDLER);
+PROVIDE(BUS_FAULT = DEFAULT_HANDLER);
+PROVIDE(USAGE_FAULT = DEFAULT_HANDLER);
+PROVIDE(SVCALL = DEFAULT_HANDLER);
+PROVIDE(PENDSV = DEFAULT_HANDLER);
+PROVIDE(SYS_TICK = DEFAULT_HANDLER);
+/* This handler is not needed on armv6m, but it shouldn't hurt to keed it here anyway */
+PROVIDE(DEBUG_MONITOR = DEFAULT_HANDLER);
+
 PROVIDE(_stack_start = ORIGIN(RAM) + LENGTH(RAM));
 
 SECTIONS

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -276,7 +276,6 @@
 #![deny(warnings)]
 #![feature(asm)]
 #![feature(core_intrinsics)]
-#![feature(global_asm)]
 #![feature(lang_items)]
 #![feature(linkage)]
 #![feature(naked_functions)]
@@ -365,43 +364,6 @@ unsafe extern "C" fn reset_handler() -> ! {
         asm!("wfi" :::: "volatile");
     }
 }
-
-#[cfg(target_arch = "arm")]
-global_asm!(
-    r#"
-.weak NMI
-NMI = DEFAULT_HANDLER
-
-.weak HARD_FAULT
-HARD_FAULT = DEFAULT_HANDLER
-
-.weak MEM_MANAGE
-MEM_MANAGE = DEFAULT_HANDLER
-
-.weak BUS_FAULT
-BUS_FAULT = DEFAULT_HANDLER
-
-.weak USAGE_FAULT
-USAGE_FAULT = DEFAULT_HANDLER
-
-.weak SVCALL
-SVCALL = DEFAULT_HANDLER
-
-.weak PENDSV
-PENDSV = DEFAULT_HANDLER
-
-.weak SYS_TICK
-SYS_TICK = DEFAULT_HANDLER
-"#
-);
-
-#[cfg(not(armv6m))]
-global_asm!(
-    r#"
-.weak DEBUG_MONITOR
-DEBUG_MONITOR = DEFAULT_HANDLER
-"#
-);
 
 #[cfg(target_arch = "arm")]
 extern "C" {


### PR DESCRIPTION
Fixes https://github.com/japaric/cortex-m-rt/issues/58

This is a breaking change for projects that are using custom linker
scripts.