### PR TITLE
Fix typo in Exception name

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -521,7 +521,7 @@ pub enum Exception {
     /// All class of fault.
     HARD_FAULT,
     /// Memory management.
-    MEN_MANAGE,
+    MEM_MANAGE,
     /// Pre-fetch fault, memory access fault.
     BUS_FAULT,
     /// Undefined instruction or illegal state.


### PR DESCRIPTION
This will make the name in `enum Exception` match the name of the exception handler function, like they already do for all other exceptions.