### PR TITLE
Update panic-semihosting to v0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ cc = "1.0.10"
 r0 = "0.2.1"
 
 [dev-dependencies]
-panic-semihosting = "0.2.0"
+panic-semihosting = "0.3.0"
 
 [features]
 device = []


### PR DESCRIPTION
To support the latest nightly. Similar to https://github.com/japaric/cortex-m-quickstart/pull/33.

Would also be great to have a new release of this package and update the discovery project/book to compile with latest nightly.

Note that I'm very new to the Rust space and these projects and not really sure if bumping this dependency have any other implications!